### PR TITLE
Add PDF statement import

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Track your personal spending by parsing Arabic or English SMS messages using a l
   * "What’s my top merchant this month?"
 * View summaries by category or total
 * Simple Streamlit web interface
+* Import transactions from PDF bank statements
 
 ---
 
@@ -72,6 +73,8 @@ python main.py
 python main.py web
 ```
 
+In the web interface you can also upload a PDF statement to import its transactions.
+
 ---
 
 ## ✨ Example SMS Input
@@ -95,6 +98,7 @@ python main.py web
 * **`ask`** → Ask any question about your data
 * **`exit`** → Quit the app
 * **`batch <file>`** → Import multiple messages from a text file
+* **`pdf <file>`** → Import transactions from a PDF statement
 * **`export markdown <file>`** → Save all data to a Markdown table
 * **`export excel <file>`** → Save all data to an Excel workbook
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 ollama
 pandas
 openpyxl
+pdfplumber

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,11 +2,20 @@ import streamlit as st
 from llm_parser import extract_transaction_from_text
 from llm_categorizer import categorize_transaction_with_llm
 from llm_qa import ask_question_about_data
-from main import save_to_db, load_all_data
+from main import save_to_db, load_all_data, import_transactions_from_pdf
 
 st.title("\U0001F4CA Local LLM Budget Tracker")
 
 message = st.text_area("Paste SMS message (Arabic or English)")
+
+pdf_file = st.file_uploader("Upload bank statement PDF", type="pdf")
+
+if st.button("Import PDF"):
+    if pdf_file is not None:
+        import_transactions_from_pdf(pdf_file)
+        st.success("Imported transactions from PDF.")
+    else:
+        st.warning("Please upload a PDF file first.")
 
 if st.button("Add Transaction"):
     if message:


### PR DESCRIPTION
## Summary
- support importing PDF statements via pdfplumber
- add new CLI command `pdf <file>`
- allow PDF uploads in Streamlit interface
- document PDF support and update dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e071104c083218e4b4c9ce1e771c0