### PR TITLE
Add PDF statement import

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Track your personal spending by parsing Arabic or English SMS messages using a l
   * "What’s my top merchant this month?"
 * View summaries by category or total
 * Simple Streamlit web interface
+* Import transactions from PDF bank statements
 
 ---
 
@@ -72,6 +73,8 @@ python main.py
 python main.py web
 ```
 
+In the web interface you can also upload a PDF statement to import its transactions.
+
 ---
 
 ## ✨ Example SMS Input
@@ -95,6 +98,7 @@ python main.py web
 * **`ask`** → Ask any question about your data
 * **`exit`** → Quit the app
 * **`batch <file>`** → Import multiple messages from a text file
+* **`pdf <file>`** → Import transactions from a PDF statement
 * **`export markdown <file>`** → Save all data to a Markdown table
 * **`export excel <file>`** → Save all data to an Excel workbook
 

--- a/main.py
+++ b/main.py
@@ -3,8 +3,9 @@ import sqlite3
 import sys
 from datetime import datetime
 import subprocess
-from typing import List
+from typing import List, Union
 import pandas as pd
+import pdfplumber
 
 from llm_parser import extract_transaction_from_text
 from llm_categorizer import categorize_transaction_with_llm
@@ -44,10 +45,35 @@ def save_to_db(data):
 def load_all_data():
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
-    c.execute("SELECT operation, card, merchant, amount, balance, timestamp, category FROM transactions")
+    # Ensure table exists so summaries work even before any data is saved
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS transactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            operation TEXT,
+            card TEXT,
+            merchant TEXT,
+            amount REAL,
+            balance REAL,
+            timestamp TEXT,
+            category TEXT
+        )
+        """
+    )
+    c.execute(
+        "SELECT operation, card, merchant, amount, balance, timestamp, category FROM transactions"
+    )
     rows = c.fetchall()
     conn.close()
-    keys = ["operation", "card", "merchant", "amount", "balance", "timestamp", "category"]
+    keys = [
+        "operation",
+        "card",
+        "merchant",
+        "amount",
+        "balance",
+        "timestamp",
+        "category",
+    ]
     return [dict(zip(keys, row)) for row in rows]
 
 
@@ -73,6 +99,19 @@ def import_messages_from_file(path: str) -> None:
         return
     for msg in messages:
         parse_and_save_message(msg)
+
+
+def import_transactions_from_pdf(source: Union[str, 'IO']) -> None:
+    """Import transactions from a PDF file path or file-like object."""
+    try:
+        with pdfplumber.open(source) as pdf:
+            for page in pdf.pages:
+                text = page.extract_text() or ""
+                lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+                for line in lines:
+                    parse_and_save_message(line)
+    except Exception as e:
+        print("Could not read PDF:", e)
 
 
 def export_to_markdown(path: str) -> None:
@@ -109,6 +148,9 @@ def main():
         if args[0] == "batch" and len(args) > 1:
             import_messages_from_file(args[1])
             return
+        if args[0] == "pdf" and len(args) > 1:
+            import_transactions_from_pdf(args[1])
+            return
         if args[0] == "export" and len(args) > 2:
             if args[1] == "markdown":
                 export_to_markdown(args[2])
@@ -121,7 +163,7 @@ def main():
 
     print(
         "💬 Enter a financial SMS message (Arabic/English), type 'summary', 'ask', 'exit',"
-        " or use 'batch <file>' / 'export <format> <file>'."
+        " or use 'batch <file>' / 'pdf <file>' / 'export <format> <file>'."
     )
 
     while True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 ollama
 pandas
 openpyxl
+pdfplumber

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,11 +2,20 @@ import streamlit as st
 from llm_parser import extract_transaction_from_text
 from llm_categorizer import categorize_transaction_with_llm
 from llm_qa import ask_question_about_data
-from main import save_to_db, load_all_data
+from main import save_to_db, load_all_data, import_transactions_from_pdf
 
 st.title("\U0001F4CA Local LLM Budget Tracker")
 
 message = st.text_area("Paste SMS message (Arabic or English)")
+
+pdf_file = st.file_uploader("Upload bank statement PDF", type="pdf")
+
+if st.button("Import PDF"):
+    if pdf_file is not None:
+        import_transactions_from_pdf(pdf_file)
+        st.success("Imported transactions from PDF.")
+    else:
+        st.warning("Please upload a PDF file first.")
 
 if st.button("Add Transaction"):
     if message:


### PR DESCRIPTION
## Summary
- support importing PDF statements via pdfplumber
- add new CLI command `pdf <file>`
- allow PDF uploads in Streamlit interface
- document PDF support and update dependencies
- fix missing table error when viewing summary in web interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e071104c083218e4b4c9ce1e771c0