### PR TITLE
Fix summary bug with numeric amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ python main.py web
 ```
 
 You can also upload a PDF statement in the web interface to import its transactions.
-=======
-In the web interface you can also upload a PDF statement to import its transactions.
 
 ---
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -31,12 +31,12 @@ if st.button("Add Transaction"):
 
 if st.button("Show Summary"):
     data = load_all_data()
-    total = sum(item['amount'] for item in data)
+    total = sum(float(item['amount']) for item in data)
     st.subheader("Total Spending")
     st.write(f"SAR {total}")
     by_cat = {}
     for item in data:
-        by_cat[item['category']] = by_cat.get(item['category'], 0) + item['amount']
+        by_cat[item['category']] = by_cat.get(item['category'], 0.0) + float(item['amount'])
     st.subheader("By Category")
     for cat, amt in by_cat.items():
         st.write(f"{cat}: SAR {amt:.2f}")


### PR DESCRIPTION
## Summary
- ensure `save_to_db` stores numeric amounts
- parse amounts and balances as floats when loading from the DB
- fix summary calculations in CLI and Streamlit app
- remove leftover merge markers from README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e9dbbca988321bea8663e5ac6438a